### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ require 'vendor/autoload.php';
 $ git clone https://github.com/epayco/epayco-php.git
 ```
 
+## Generate Bearer Token
+```
+$epaycoClient = new \Epayco\Client();
+$epaycoClient->authentication("API_KEY", "PRIVATE_KEY");		
+```
+
 ## Usage
 
 ```php


### PR DESCRIPTION
Saludos,

Estoy haciendo la integración desde Symfony 4 y siempre que disparaba cualquier opción del SDK me arrojaba que faltaba el token Bearer. Cabe aclarar que obviamente estaba ejecutando $epayco = new Epayco\Epayco con las respectivas credenciales. Peros siempre me decia que faltaba el token bearer.

Revisando entre las clases del vendor, vi que contaba con la clase Client y dentro de ella el metodo autenticate, lo probe y todo funciona perfecto ahora.

Gran trabajo, el SDK esta muy bueno!!!