### PR TITLE
Epayco\Resources\ErrorException' not found

### DIFF
--- a/src/Resources/Cash.php
+++ b/src/Resources/Cash.php
@@ -3,6 +3,7 @@
 namespace Epayco\Resources;
 
 use Epayco\Resource;
+use Epayco\Exceptions\ErrorException;
 
 /**
  * Cash payment methods


### PR DESCRIPTION
The 'use' of the ErrorException class is added, since it is being used in the Resource Cash file and it belongs to another namespace.

#16 